### PR TITLE
fix(readme): broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ markit.nvim enhances marks experience in neovim, making it easier to mark and na
 ### ⚙️ Requirements
 
 - Neovim >= 0.6.0
-- [pickme.nvim](https://github.com/2kabhishek/picker.nvim) (for picker integration)
+- [pickme.nvim](https://github.com/2kabhishek/pickme.nvim) (for picker integration)
 
 ### 💻 Installation
 


### PR DESCRIPTION
## What does the PR do? (Required)

- [x] Fixes a broken markdown link to pickme.nvim

Fixes a markdown link with link text "pickme.nvim" but linking to `2kabhishek/picker.nvim`. This corrects the link to point to `2kabhishek/pickme.nvim`.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

Please include relevant screenshots, recordings, or logs to support your changes.
